### PR TITLE
testing icons path after adding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ Models > new "classes" option added to most for the block itself, not block-item
 For parity with how Edge Del. Svc. block styles are authored, I used "text" with "multi"=true for classes field to type in multiple classes.
 - See table.json and video.json for examples of multiselect with child style options.
 - You can also use 1 "multiselect" for classes field (with intuitive labels) to allow choosing multiple that you've pre-defined.
+
+## paths.json
+You have to add all json files you want to access publicly in mappings. Can add a new included path to experience fragments, then map it to be available via /fragments.
+"mappings": [ "/content/experience-fragments/yourproject/:/fragments/" ],
+"includes": [ "/content/experience-fragments/yourproject/"]
+
+To publish icons, pdfs, or videos, you need to add cloud config per https://www.aem.live/docs/universal-editor-assets.

--- a/paths.json
+++ b/paths.json
@@ -2,7 +2,8 @@
   "mappings": [
     "/content/sta-boilerplate/:/",
     "/content/sta-boilerplate/configuration:/.helix/config.json",
-    "/content/sta-boilerplate/metadata:/metadata.json"
+    "/content/sta-boilerplate/metadata:/metadata.json",
+    "/content/dam/sta-boilerplate/icons:/icons"
   ],
   "includes": [
     "/content/sta-boilerplate/"

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -54,6 +54,10 @@
   src: local('Arial');
 }
 
+/* Use 600, 900, 1200 and maybe 1800px. Don't use customer breakpoints per
+ https://www.freecodecamp.org/news/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862/ 
+ */
+
 @media (width >= 900px) {
   :root {
     /* body sizes */


### PR DESCRIPTION
added the cloud config to /content/dam/sta-boilerplate folder, added also as a mapping in paths.json.
Did not add to "includes", I want to test if it is needed.